### PR TITLE
Reduce tons of code duplication

### DIFF
--- a/hyper_search.py
+++ b/hyper_search.py
@@ -16,52 +16,8 @@ import pywt
 from dotenv import load_dotenv
 import os
 import tensorflow_addons as tfa
-from train import upper_shadow, lower_shadow, add_daily_open_feature, add_technical_indicators, scale_data, perform_wavelet_transform, create_dataset, calculate_weighted_rmse, decaying_rmse_loss
+from train import scale_data, perform_wavelet_transform, create_dataset, calculate_weighted_rmse, decaying_rmse_loss, get_data
 
-# Load the .env file
-load_dotenv()
-
-#Load the data from the pickle file
-with open('data/2y_data.pickle', 'rb') as file:
-    data_structure = pickle.load(file)
-
-data_structure = [data_structure[0],
-data_structure[1],
-data_structure[2],
-data_structure[3],
-data_structure[4]]
-
-data_array = np.array(data_structure).T
-
-#Assuming the structure is [timestamps, close, high, low, volume]
-timestamps = pd.to_datetime(data_array[:, 0], unit='ms')
-close_prices = data_array[:, 1]
-high_prices = data_array[:, 2]
-low_prices = data_array[:, 3]
-volumes = data_array[:, 4]
-
-# Combine all features into a DataFrame
-data_df = pd.DataFrame({
-    'timestamps': timestamps,
-    'close': close_prices,
-    'high': high_prices,
-    'low': low_prices,
-    'volume': volumes
-})
-
-
-# Create more advanced technical indicators
-df = add_technical_indicators(data_df)
-# remove all NaN values
-df.dropna(inplace=True)
-df.drop('timestamps', axis=1, inplace=True)
-df.drop('date', axis=1, inplace=True)
-
-data  = df.values
-
-scaler = MinMaxScaler(feature_range=(0, 1))
-
-num_features = data.shape[1]
 
 # Optuna objective
 def objective(trial):
@@ -122,9 +78,9 @@ def objective(trial):
     
     # Data prep
     if wavelet_transform == "True": 
-        X, y = create_dataset(scale_data(perform_wavelet_transform(data, wavelet=wavelet_type, level=decomposition_level)), num_previous_intervals, 100)
+        X, y = create_dataset(scale_data(perform_wavelet_transform(data, wavelet=wavelet_type, level=decomposition_level), scaler), num_previous_intervals, 100)
     else: 
-        X, y = create_dataset(scale_data(data), num_previous_intervals, 100)
+        X, y = create_dataset(scale_data(data, scaler), num_previous_intervals, 100)
     
     # Split into train and test set
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42, shuffle=False)
@@ -164,10 +120,19 @@ def objective(trial):
     return rmse
 
 
-database_url = os.environ.get('DATABASE_URL')
+if __name__ == "__main__":
 
-#Create Study
-study = optuna.create_study(direction='minimize', study_name="regularization", load_if_exists=True, storage=database_url)
+    # Load the .env file
+    load_dotenv()
 
-# Do the study
-study.optimize(objective)  # Adjust the number of trials
+    df, data, num_features = get_data('data', '2y_data.pickle')
+
+    scaler = MinMaxScaler(feature_range=(0, 1))
+
+    database_url = os.environ.get('DATABASE_URL')
+
+    #Create Study
+    study = optuna.create_study(direction='minimize', study_name="regularization", load_if_exists=True, storage=database_url)
+
+    # Do the study
+    study.optimize(objective)  # Adjust the number of trials

--- a/miner.py
+++ b/miner.py
@@ -21,6 +21,7 @@ import numpy as np
 import pandas as pd
 from vali_config import ValiConfig
 import pickle
+from train import data_pipeline, scale_data, perform_wavelet_transform
 
 
 def get_config():
@@ -181,114 +182,11 @@ def main( config ):
         data_structure = synapse_data_structure.T[-601:, :].T
         bt.logging.debug(f"length of windowed ds [{len(data_structure[0])}]")
 
-        data_array = data_structure.T
-
-        #Assuming the structure is [timestamps, close, high, low, volume]
-        timestamps = pd.to_datetime(data_array[:, 0], unit='ms')
-        close_prices = data_array[:, 1]
-        high_prices = data_array[:, 2]
-        low_prices = data_array[:, 3]
-        volumes = data_array[:, 4]
-
-        # Combine all features into a DataFrame
-        data_df = pd.DataFrame({
-            'timestamps': timestamps,
-            'close': close_prices,
-            'high': high_prices,
-            'low': low_prices,
-            'volume': volumes
-        })
-
-        # Technical indicator helper functions
-        def upper_shadow(df): return df['high'] - np.maximum(df['close'], df['open'])
-        def lower_shadow(df): return np.minimum(df['close'], df['open']) - df['low']
-        def add_daily_open_feature(df):
-            # Convert timestamps to dates if necessary (assuming 'timestamps' is in datetime format)
-            df['date'] = df['timestamps'].dt.date
-            # Group by date and take the last 'close' for each day
-            daily_open_prices = df.groupby('date')['close'].last()
-            # Shift the daily_open_prices to use the last 'close' as the 'open' for the following day.
-            daily_open_prices = daily_open_prices.shift(1)
-            # Map the daily_open_prices to each corresponding timestamps
-            df['open'] = df['date'].map(daily_open_prices)
-            # Handle the 'open' for the first day in the dataset
-            df['open'].bfill(inplace=True)
-            return df
-
-        # Create more advanced technical indicators
-        def add_technical_indicators(df):
-            # Simple Moving Average
-            df['SMA_5'] = df['close'].rolling(window=5).mean()
-            df['SMA_15'] = df['close'].rolling(window=15).mean()
-
-            # Exponential Moving Average
-            df['EMA_5'] = df['close'].ewm(span=5, adjust=False).mean()
-            df['EMA_15'] = df['close'].ewm(span=15, adjust=False).mean()
-
-            # Relative Strength Index
-            delta = df['close'].diff()
-            gain = (delta.where(delta > 0, 0)).rolling(window=14).mean()
-            loss = (-delta.where(delta < 0, 0)).rolling(window=14).mean()
-            RS = gain / loss
-            df['RSI'] = 100 - (100 / (1 + RS))
-
-            # Moving Average Convergence Divergence
-            exp1 = df['close'].ewm(span=12, adjust=False).mean()
-            exp2 = df['close'].ewm(span=26, adjust=False).mean()
-            df['MACD'] = exp1 - exp2
-            df['Signal_Line'] = df['MACD'].ewm(span=9, adjust=False).mean()
-            
-            # Make sure the 'timestamps' column is a datetime type before applying the function
-            df['timestamps'] = pd.to_datetime(df['timestamps'])
-            df = add_daily_open_feature(df)
-            df['upper_Shadow'] = upper_shadow(df)
-            df['lower_Shadow'] = lower_shadow(df)
-            df["high_div_low"] = df["high"] / df["low"]
-            df['trade'] = df['close'] - df['open']
-            df['shadow1'] = df['trade'] / df['volume']
-            df['shadow3'] = df['upper_Shadow'] / df['volume']
-            df['shadow5'] = df['lower_Shadow'] / df['volume']
-            df['mean1'] = (df['shadow5'] + df['shadow3']) / 2
-            df['mean2'] = (df['shadow1'] + df['volume']) / 2
-
-            return df
-
-        df = add_technical_indicators(data_df)
-        # remove all NaN values
-        df.dropna(inplace=True)
-        df.drop('timestamps', axis=1, inplace=True)
-        df.drop('date', axis=1, inplace=True)
-
-        data  = df.values
-
-        num_features = data.shape[1]
-
-        # Function to scale dataset
-        def scale_data(data):
-            data_scaled = scaler.fit_transform(data)
-            return data_scaled
-
-        def perform_wavelet_transform(data, wavelet='db4', level=4):
-            # Initialize an empty list to store the denoised features
-            data_denoised_list = []
-
-            # Apply wavelet transform to each feature separately
-            for i in range(data.shape[1]):
-                coeffs = pywt.wavedec(data[:, i], wavelet=wavelet, level=level)
-                # Zero out the high-frequency components for denoising
-                coeffs[1:] = [np.zeros_like(coeff) for coeff in coeffs[1:]]
-                # Reconstruct the denoised signal
-                data_denoised = pywt.waverec(coeffs, wavelet)
-                # Append the denoised feature to the list
-                data_denoised_list.append(data_denoised)
-
-            # Combine the denoised features back into a single array
-            data_denoised_combined = np.column_stack(data_denoised_list)
-            return data_denoised_combined
+        df, data, num_features = data_pipeline(data_structure)
 
         wavelet_type = "db4"
         decomposition_level = 4
-        input = scale_data(perform_wavelet_transform(data, wavelet=wavelet_type, level=decomposition_level))
+        input = scale_data(perform_wavelet_transform(data, wavelet=wavelet_type, level=decomposition_level), scaler)
 
         # Evaluate the model
         predictions = model.predict(input[-57:].reshape([1, 57, num_features]))

--- a/test_model.py
+++ b/test_model.py
@@ -9,74 +9,35 @@ import pywt
 from dotenv import load_dotenv
 import os
 import tensorflow_addons as tfa
-from train import upper_shadow, lower_shadow, add_daily_open_feature, add_technical_indicators, scale_data, perform_wavelet_transform, create_dataset, calculate_weighted_rmse, decaying_rmse_loss
-
-# Load our model
-model = tf.keras.models.load_model(f'trained_models/hyper_model.h5', compile=False)
-# Load our scaler
-with open(f'trained_models/hyper_scaler.pkl', 'rb') as file:
-    scaler = pickle.load(file)
-
-#Load the data from the pickle file
-with open('data/2y_data.pickle', 'rb') as file:
-    data_structure = pickle.load(file)
-
-data_structure = [data_structure[0],
-data_structure[1],
-data_structure[2],
-data_structure[3],
-data_structure[4]]
-
-data_array = np.array(data_structure).T
+from train import scale_data, perform_wavelet_transform, get_data, load_scaler_from_pickle
 
 
-#Assuming the structure is [timestamps, close, high, low, volume]
-timestamps = pd.to_datetime(data_array[:, 0], unit='ms')
-close_prices = data_array[:, 1]
-high_prices = data_array[:, 2]
-low_prices = data_array[:, 3]
-volumes = data_array[:, 4]
+if __name__ == "__main__":
+    # Load our model
+    model = tf.keras.models.load_model(f'trained_models/hyper_model.h5', compile=False)
+    # Load our scaler
+    scaler = load_scaler_from_pickle()
 
-# Combine all features into a DataFrame
-data_df = pd.DataFrame({
-    'timestamps': timestamps,
-    'close': close_prices,
-    'high': high_prices,
-    'low': low_prices,
-    'volume': volumes
-})
+    df, data, num_features = get_data('data', '2y_data.pickle')
 
+    wavelet_type = "db4"
+    decomposition_level = 4
+    input = scale_data(perform_wavelet_transform(data, wavelet=wavelet_type, level=decomposition_level), scaler)
 
+    # Evaluate the model
+    predictions = model.predict(input[-57:].reshape([1, 57, num_features]))
 
-df = add_technical_indicators(data_df)
-# remove all NaN values
-df.dropna(inplace=True)
-df.drop('timestamps', axis=1, inplace=True)
-df.drop('date', axis=1, inplace=True)
+    # This is literally fucking stupid. How does ML work like this.
+    # Create a zero-filled array with the same number of samples and timesteps
+    modified_predictions = np.zeros((predictions.shape[0], predictions.shape[1], num_features))
+    # Place predictions into the first feature of this array
+    modified_predictions[:, :, 0] = predictions
+    modified_predictions_reshaped = modified_predictions.reshape(-1, num_features)
+    # Apply inverse_transform
+    original_scale_predictions = scaler.inverse_transform(modified_predictions_reshaped)
+    # Reshape back to original predictions shape, if needed
+    original_scale_predictions = original_scale_predictions[:, 0].reshape(predictions.shape[0], predictions.shape[1])
 
-data  = df.values
+    predicted_closes = original_scale_predictions[0].tolist()
 
-num_features = data.shape[1]
-
-
-wavelet_type = "db4"
-decomposition_level = 4
-input = scale_data(perform_wavelet_transform(data, wavelet=wavelet_type, level=decomposition_level))
-
-# Evaluate the model
-predictions = model.predict(input[-57:].reshape([1, 57, num_features]))
-
-# This is literally fucking stupid. How does ML work like this.
-# Create a zero-filled array with the same number of samples and timesteps
-modified_predictions = np.zeros((predictions.shape[0], predictions.shape[1], num_features))
-# Place predictions into the first feature of this array
-modified_predictions[:, :, 0] = predictions
-modified_predictions_reshaped = modified_predictions.reshape(-1, num_features)
-# Apply inverse_transform
-original_scale_predictions = scaler.inverse_transform(modified_predictions_reshaped)
-# Reshape back to original predictions shape, if needed
-original_scale_predictions = original_scale_predictions[:, 0].reshape(predictions.shape[0], predictions.shape[1])
-
-predicted_closes = original_scale_predictions[0].tolist()
-
-print(predicted_closes)
+    print(predicted_closes)

--- a/train.py
+++ b/train.py
@@ -267,9 +267,20 @@ early_stopping = EarlyStopping(monitor='val_loss', patience=8, restore_best_weig
 # Train the model
 model.fit(X_train, y_train, epochs=100, batch_size=batch_size, validation_split=0.1, verbose=0, callbacks=[early_stopping])
 
-# Save the scaler
-with open('trained_models/hyper_scaler.pkl', 'wb') as file:
-    pickle.dump(scaler, file)
+def save_scaler_as_pickle(scaler):
+    directory = 'trained_models'
+    filename = 'hyper_scaler.pkl'
+    filepath = os.path.join(directory, filename)
+
+    # Make sure the directory exists
+    if not os.path.exists(directory):
+        os.mkdir(directory)
+
+    # Save the scaler
+    with open(filepath, 'wb') as file:
+        pickle.dump(scaler, file)
+
+save_scaler_as_pickle(scaler)
 
 # Evaluate the model
 predictions = model.predict(X_test)

--- a/train.py
+++ b/train.py
@@ -17,47 +17,86 @@ from dotenv import load_dotenv
 import os
 import tensorflow_addons as tfa
 
-# Load the .env file
-load_dotenv()
 
-#Load the data from the pickle file
-with open('data/2y_data.pickle', 'rb') as file:
-    data_structure = pickle.load(file)
+def get_data_struct_from_pickle(directory, filename):
+    filepath = os.path.join(directory, filename)
 
-data_structure = [data_structure[0],
-data_structure[1],
-data_structure[2],
-data_structure[3],
-data_structure[4]]
+    #Load the data from the pickle file
+    with open(filepath, 'rb') as file:
+        data_structure = pickle.load(file)
 
-data_array = np.array(data_structure).T
+    data_structure = [data_structure[0],
+    data_structure[1],
+    data_structure[2],
+    data_structure[3],
+    data_structure[4]]
 
-#Assuming the structure is [timestamps, close, high, low, volume]
-timestamps = pd.to_datetime(data_array[:, 0], unit='ms')
-close_prices = data_array[:, 1]
-high_prices = data_array[:, 2]
-low_prices = data_array[:, 3]
-volumes = data_array[:, 4]
+    return data_structure
+
+
+def data_struct_to_data_frame(data_structure):
+    data_array = np.array(data_structure).T
+
+    #Assuming the structure is [timestamps, close, high, low, volume]
+    timestamps = pd.to_datetime(data_array[:, 0], unit='ms')
+    close_prices = data_array[:, 1]
+    high_prices = data_array[:, 2]
+    low_prices = data_array[:, 3]
+    volumes = data_array[:, 4]
+
+    # Combine all features into a DataFrame
+    data_df = pd.DataFrame({
+        'timestamps': timestamps,
+        'close': close_prices,
+        'high': high_prices,
+        'low': low_prices,
+        'volume': volumes
+    })
+
+    return data_df
+
+
+def clean_data(df):
+    # remove all NaN values
+    df.dropna(inplace=True)
+    df.drop('timestamps', axis=1, inplace=True)
+    df.drop('date', axis=1, inplace=True)
+
+    return df
+
+
 """
-#Combine all features into a single array
-data_combined = np.column_stack((timestamps, close_prices, high_prices, low_prices, volumes))
-
-# Assuming data_array is your numpy array with columns in the order: timestamps, close, high, low, volume
-column_names = ['close', 'high', 'low', 'volume']
-data_df = pd.DataFrame(data_combined, columns=column_names)
+Take a raw data_structure, transform it to a data frame, add features, and clean it
 """
-# Combine all features into a DataFrame
-data_df = pd.DataFrame({
-    'timestamps': timestamps,
-    'close': close_prices,
-    'high': high_prices,
-    'low': low_prices,
-    'volume': volumes
-})
+def data_pipeline(data_structure):
+    data_df = data_struct_to_data_frame(data_structure)
+    
+    df = add_technical_indicators(data_df)
+    
+    df = clean_data(df)
+
+    data = df.values    
+
+    num_features = data.shape[1]
+
+    return df, data, num_features
+
+
+def get_data(directory = 'data', filename = '2y_data.pickle'):
+    data_structure = get_data_struct_from_pickle(directory, filename)
+
+    df, data, num_features = data_pipeline(data_structure)
+
+    return df, data, num_features
+
 
 # Technical indicator helper functions
 def upper_shadow(df): return df['high'] - np.maximum(df['close'], df['open'])
+
+
 def lower_shadow(df): return np.minimum(df['close'], df['open']) - df['low']
+
+
 def add_daily_open_feature(df):
     # Convert timestamps to dates if necessary (assuming 'timestamps' is in datetime format)
     df['date'] = df['timestamps'].dt.date
@@ -70,6 +109,7 @@ def add_daily_open_feature(df):
     # Handle the 'open' for the first day in the dataset
     df['open'].bfill(inplace=True)
     return df
+
 
 # Create more advanced technical indicators
 def add_technical_indicators(df):
@@ -109,20 +149,12 @@ def add_technical_indicators(df):
 
     return df
 
-df = add_technical_indicators(data_df)
-# remove all NaN values
-df.dropna(inplace=True)
-df.drop('timestamps', axis=1, inplace=True)
-df.drop('date', axis=1, inplace=True)
-
-data  = df.values
-
-scaler = MinMaxScaler(feature_range=(0, 1))
 
 # Function to scale dataset
-def scale_data(data):
+def scale_data(data, scaler):
     data_scaled = scaler.fit_transform(data)
     return data_scaled
+
 
 def perform_wavelet_transform(data, wavelet='db1', level=2):
     # Initialize an empty list to store the denoised features
@@ -142,6 +174,7 @@ def perform_wavelet_transform(data, wavelet='db1', level=2):
     data_denoised_combined = np.column_stack(data_denoised_list)
     return data_denoised_combined
 
+
 # Function to create dataset
 def create_dataset(data, input_time_steps=100, future_intervals=100):
     X, y = [], []
@@ -149,6 +182,7 @@ def create_dataset(data, input_time_steps=100, future_intervals=100):
         X.append(data[i:(i + input_time_steps), :])
         y.append(data[(i + input_time_steps):(i + input_time_steps + future_intervals), 0])
     return np.array(X), np.array(y)
+
 
 # Scoring function for model
 def calculate_weighted_rmse(predictions: np, actual: np) -> float:
@@ -175,6 +209,7 @@ def calculate_weighted_rmse(predictions: np, actual: np) -> float:
     
     return mean_rmse
 
+
 # Objective function to be optimized
 def decaying_rmse_loss(y_true, y_pred):
     k = 0.001  # decay rate, adjust as needed
@@ -197,76 +232,6 @@ def decaying_rmse_loss(y_true, y_pred):
     return weighted_rmse
 
 
-num_features = data.shape[1]
-
-##### Add your hyperparameter options
-#Layers
-hidden_units = 947
-num_layers = 1
-layer_multiplier = 1
-dropout_rate = 0.1352979618569746
-num_previous_intervals = 57
-
-# Elastic Net Regularization hyperparameters
-l1_reg = 1.2669911888395433e-05
-l2_reg = 1.0003319428243117e-05
-
-# Optimizer
-learning_rate = 0.002546037429204024
-optimizer_type = "ranger"
-total_steps = 5398
-warmup_proportion = 0.17004444961347331
-min_lr = 1.751520128062939e-06
-sync_period = 6
-slow_step_size = 0.5859028778720838
-
-# Wavelet
-wavelet_transform = "True"
-wavelet_type = "db4"
-decomposition_level = 4
-
-#Training
-batch_size = 960
-
-if(optimizer_type == "adam"):
-    optimizer=tf.keras.optimizers.Adam(learning_rate=learning_rate)
-elif(optimizer_type == "ranger"):
-    radam = tfa.optimizers.RectifiedAdam(
-        learning_rate=learning_rate,
-        total_steps=10000,
-        warmup_proportion=0.1,
-        min_lr=1e-5,
-    )
-    optimizer = tfa.optimizers.Lookahead(radam, sync_period=6, slow_step_size=0.5)
-else:
-    optimizer=tf.keras.optimizers.Adam(learning_rate=learning_rate)
-
-# Create a model with the current trial's hyperparameters
-model = Sequential()
-for i in range(num_layers):
-    if i == 0:
-        model.add(LSTM(hidden_units, return_sequences=num_layers > 1, input_shape=(num_previous_intervals, num_features)))
-    else:
-        model.add(LSTM(hidden_units, return_sequences=i < num_layers - 1))
-    model.add(Dropout(dropout_rate))
-model.add(Dense(100))
-model.compile(optimizer=optimizer, loss=decaying_rmse_loss)
-
-# Data prep
-if wavelet_transform == "True": 
-    X, y = create_dataset(scale_data(perform_wavelet_transform(data, wavelet=wavelet_type, level=decomposition_level)), num_previous_intervals, 100)
-else: 
-    X, y = create_dataset(scale_data(data), num_previous_intervals, 100)
-
-# Split into train and test set
-X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42, shuffle=False)
-
-# Early stopping callback
-early_stopping = EarlyStopping(monitor='val_loss', patience=8, restore_best_weights=True)
-
-# Train the model
-model.fit(X_train, y_train, epochs=100, batch_size=batch_size, validation_split=0.1, verbose=0, callbacks=[early_stopping])
-
 def save_scaler_as_pickle(scaler):
     directory = 'trained_models'
     filename = 'hyper_scaler.pkl'
@@ -280,35 +245,121 @@ def save_scaler_as_pickle(scaler):
     with open(filepath, 'wb') as file:
         pickle.dump(scaler, file)
 
-save_scaler_as_pickle(scaler)
 
-# Evaluate the model
-predictions = model.predict(X_test)
-# This is literally fucking stupid. How does ML work like this.
-# Create a zero-filled array with the same number of samples and timesteps, but with 5 features
-modified_predictions = np.zeros((predictions.shape[0], predictions.shape[1], num_features))
-# Place predictions into the first feature of this array
-modified_predictions[:, :, 0] = predictions
-# Reshape modified_predictions to 2D (51911*100, 5) for inverse_transform
-modified_predictions_reshaped = modified_predictions.reshape(-1, num_features)
-# Apply inverse_transform
-original_scale_predictions = scaler.inverse_transform(modified_predictions_reshaped)
-# Reshape back to original predictions shape, if needed
-original_scale_predictions = original_scale_predictions[:, 0].reshape(predictions.shape[0], predictions.shape[1])
-# Create a zero-filled array with the same number of samples and timesteps, but with 5 features
-modified_y_test = np.zeros((y_test.shape[0], y_test.shape[1], num_features))
-# Place y_test into the first feature of this array
-modified_y_test[:, :, 0] = y_test
-# Reshape modified_y_test to 2D (51911*100, 5) for inverse_transform
-modified_y_test_reshaped = modified_y_test.reshape(-1, num_features)
-# Apply inverse_transform
-original_scale_y_test = scaler.inverse_transform(modified_y_test_reshaped)
-# Reshape back to original y_test shape, if needed
-# (Selecting only the first feature, assuming y_test corresponds to the first feature)
-original_scale_y_test = original_scale_y_test[:, 0].reshape(y_test.shape[0], y_test.shape[1])
-rmse = calculate_weighted_rmse(original_scale_predictions, original_scale_y_test)
+def load_scaler_from_pickle(directory = 'trained_models', filename = 'hyper_scaler.pkl'):
+    filepath = os.path.join(directory, filename)
 
-print(f"Models RMSE: {rmse}")
+    with open(filepath, 'rb') as file:
+        scaler = pickle.load(file)
+    
+    return scaler
 
-# Save the trained model
-model.save('trained_models/hyper_model.h5')
+
+if __name__ == "__main__":
+    # Load the .env file
+    load_dotenv()
+
+    df, data, num_features = get_data('data', '2y_data.pickle')
+
+    scaler = MinMaxScaler(feature_range=(0, 1))
+
+    ##### Add your hyperparameter options
+    #Layers
+    hidden_units = 947
+    num_layers = 1
+    layer_multiplier = 1
+    dropout_rate = 0.1352979618569746
+    num_previous_intervals = 57
+
+    # Elastic Net Regularization hyperparameters
+    l1_reg = 1.2669911888395433e-05
+    l2_reg = 1.0003319428243117e-05
+
+    # Optimizer
+    learning_rate = 0.002546037429204024
+    optimizer_type = "ranger"
+    total_steps = 5398
+    warmup_proportion = 0.17004444961347331
+    min_lr = 1.751520128062939e-06
+    sync_period = 6
+    slow_step_size = 0.5859028778720838
+
+    # Wavelet
+    wavelet_transform = "True"
+    wavelet_type = "db4"
+    decomposition_level = 4
+
+    #Training
+    batch_size = 960
+
+    if(optimizer_type == "adam"):
+        optimizer=tf.keras.optimizers.Adam(learning_rate=learning_rate)
+    elif(optimizer_type == "ranger"):
+        radam = tfa.optimizers.RectifiedAdam(
+            learning_rate=learning_rate,
+            total_steps=10000,
+            warmup_proportion=0.1,
+            min_lr=1e-5,
+        )
+        optimizer = tfa.optimizers.Lookahead(radam, sync_period=6, slow_step_size=0.5)
+    else:
+        optimizer=tf.keras.optimizers.Adam(learning_rate=learning_rate)
+
+    # Create a model with the current trial's hyperparameters
+    model = Sequential()
+    for i in range(num_layers):
+        if i == 0:
+            model.add(LSTM(hidden_units, return_sequences=num_layers > 1, input_shape=(num_previous_intervals, num_features)))
+        else:
+            model.add(LSTM(hidden_units, return_sequences=i < num_layers - 1))
+        model.add(Dropout(dropout_rate))
+    model.add(Dense(100))
+    model.compile(optimizer=optimizer, loss=decaying_rmse_loss)
+
+    # Data prep
+    if wavelet_transform == "True": 
+        X, y = create_dataset(scale_data(perform_wavelet_transform(data, wavelet=wavelet_type, level=decomposition_level), scaler), num_previous_intervals, 100)
+    else: 
+        X, y = create_dataset(scale_data(data, scaler), num_previous_intervals, 100)
+
+    # Split into train and test set
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42, shuffle=False)
+
+    # Early stopping callback
+    early_stopping = EarlyStopping(monitor='val_loss', patience=8, restore_best_weights=True)
+
+    # Train the model
+    model.fit(X_train, y_train, epochs=100, batch_size=batch_size, validation_split=0.1, verbose=0, callbacks=[early_stopping])
+
+    save_scaler_as_pickle(scaler)
+
+    # Evaluate the model
+    predictions = model.predict(X_test)
+    # This is literally fucking stupid. How does ML work like this.
+    # Create a zero-filled array with the same number of samples and timesteps, but with 5 features
+    modified_predictions = np.zeros((predictions.shape[0], predictions.shape[1], num_features))
+    # Place predictions into the first feature of this array
+    modified_predictions[:, :, 0] = predictions
+    # Reshape modified_predictions to 2D (51911*100, 5) for inverse_transform
+    modified_predictions_reshaped = modified_predictions.reshape(-1, num_features)
+    # Apply inverse_transform
+    original_scale_predictions = scaler.inverse_transform(modified_predictions_reshaped)
+    # Reshape back to original predictions shape, if needed
+    original_scale_predictions = original_scale_predictions[:, 0].reshape(predictions.shape[0], predictions.shape[1])
+    # Create a zero-filled array with the same number of samples and timesteps, but with 5 features
+    modified_y_test = np.zeros((y_test.shape[0], y_test.shape[1], num_features))
+    # Place y_test into the first feature of this array
+    modified_y_test[:, :, 0] = y_test
+    # Reshape modified_y_test to 2D (51911*100, 5) for inverse_transform
+    modified_y_test_reshaped = modified_y_test.reshape(-1, num_features)
+    # Apply inverse_transform
+    original_scale_y_test = scaler.inverse_transform(modified_y_test_reshaped)
+    # Reshape back to original y_test shape, if needed
+    # (Selecting only the first feature, assuming y_test corresponds to the first feature)
+    original_scale_y_test = original_scale_y_test[:, 0].reshape(y_test.shape[0], y_test.shape[1])
+    rmse = calculate_weighted_rmse(original_scale_predictions, original_scale_y_test)
+
+    print(f"Models RMSE: {rmse}")
+
+    # Save the trained model
+    model.save('trained_models/hyper_model.h5')


### PR DESCRIPTION
Using `train.py` as the source of all functions, since it seems to be the common thread. In all the other files that had duplicated code from `train.py`, it now instead just imports the function. Also fixed a `Folder does not exist error` that occurred when trying to save a model for the first time (and the folder 'trained_models' doesn't exist)


I have locally tested `train.py` and `test_model.py` and they work as expected. However, I can't run `hyper_search.py` locally (It ends with an out of memory error), and I'm not sure how to run `miner.py` just yet - so you'll have to test those latter 2 files yourself.

Sorry for the big branch, I got carried away. I can split this into smaller ones if you want